### PR TITLE
added implementations for Box and Dynamically Sized Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ homepage = "https://github.com/Kixunil/same"
 repository = "https://github.com/Kixunil/same"
 keywords = ["identity", "comparison", "equality", "references"]
 categories = ["algorithms", "no-std", "rust-patterns"]
-maintenance = "passively-maintained"
 license = "MITNFA"
 
 [features]
 default = ["std"]
 std = []
+
+[badges]
+maintenance = { status = "passively-maintained" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,13 @@ where
 #[cfg(feature = "std")]
 impl<T> Same for std::boxed::Box<T>
 where
-    T: ?Sized + Same,
+    T: ?Sized,
 {
     fn same(&self, other: &Self) -> bool {
-        (**self).same(&**other)
+        let a: *const T = &**self;
+        let b: *const T = &**other;
+
+        a == b
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,8 @@ where
 pub struct RefCmp<T: Same + ?Sized>(pub T);
 
 impl<T: Same + ?Sized> RefCmp<T> {
+    /// Creates a reference to `RefCmp<T>` from a reference to `T` without
+    /// copying.
     pub fn from_ref(inner: &T) -> &Self {
         // this is safe thanks to #[repr(transparent)]
         unsafe { &*(inner as *const _ as *const Self) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 //! This crate provides mainly the trait `Some` which can be used on *shared*
 //! reference types. (`&T`, `Rc`, `Arc`). It enables the users to test identity
 //! of objects. It's analogous to `PartialEq`, which tests *equality* instead.
-//! 
+//!
 //! Additionally, this crate provides `RefHash` trait, which is used for hashing
 //! references and `RefCmp` wrapper struct, which implements `Eq`, `PartialEq`
 //! and `Hash` by delegating to `Same` and `RefHash` traits. This is mainly
 //! useful if one wants to store objects in `HashSet` or similar data structure,
 //! with.
-//! 
+//!
 //! This crate is `no_std`-compatible.
 
 #![no_std]
@@ -58,30 +58,52 @@ pub trait RefHash {
     fn ref_hash<H: Hasher>(&self, hasher: &mut H);
 }
 
-impl<'a, T> Same for &'a T {
+impl<'a, T> Same for &'a T
+where
+    T: ?Sized,
+{
     fn same(&self, other: &Self) -> bool {
         let a: *const T = *self;
         let b: *const T = *other;
-        
+
         a == b
     }
 }
 
 #[cfg(feature = "std")]
-impl<T> Same for std::rc::Rc<T> {
+impl<T> Same for std::boxed::Box<T>
+where
+    T: ?Sized + Same,
+{
+    fn same(&self, other: &Self) -> bool {
+        (**self).same(&**other)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> Same for std::rc::Rc<T>
+where
+    T: ?Sized,
+{
     fn same(&self, other: &Self) -> bool {
         std::rc::Rc::ptr_eq(self, other)
     }
 }
 
 #[cfg(feature = "std")]
-impl<T> Same for std::sync::Arc<T> {
+impl<T> Same for std::sync::Arc<T>
+where
+    T: ?Sized,
+{
     fn same(&self, other: &Self) -> bool {
         std::sync::Arc::ptr_eq(self, other)
     }
 }
 
-impl<'a, T> RefHash for &'a T {
+impl<'a, T> RefHash for &'a T
+where
+    T: ?Sized,
+{
     fn ref_hash<H: Hasher>(&self, hasher: &mut H) {
         let ptr: *const T = *self;
 
@@ -90,14 +112,30 @@ impl<'a, T> RefHash for &'a T {
 }
 
 #[cfg(feature = "std")]
-impl<T> RefHash for std::rc::Rc<T> {
+impl<T> RefHash for std::boxed::Box<T>
+where
+    T: ?Sized,
+{
     fn ref_hash<H: Hasher>(&self, hasher: &mut H) {
         (&**self).ref_hash(hasher);
     }
 }
 
 #[cfg(feature = "std")]
-impl<T> RefHash for std::sync::Arc<T> {
+impl<T> RefHash for std::rc::Rc<T>
+where
+    T: ?Sized,
+{
+    fn ref_hash<H: Hasher>(&self, hasher: &mut H) {
+        (&**self).ref_hash(hasher);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> RefHash for std::sync::Arc<T>
+where
+    T: ?Sized,
+{
     fn ref_hash<H: Hasher>(&self, hasher: &mut H) {
         (&**self).ref_hash(hasher);
     }
@@ -113,8 +151,7 @@ impl<T> RefHash for std::sync::Arc<T> {
 /// ```
 /// use same::RefCmp;
 ///
-/// use std::rc::Rc;
-/// use std::collections::HashSet;
+/// use std::{collections::HashSet, rc::Rc};
 ///
 /// let a = ::std::sync::Arc::new(42);
 /// let a_cloned = a.clone();
@@ -127,22 +164,30 @@ impl<T> RefHash for std::sync::Arc<T> {
 /// // but `b` doesn't, even though it has same value.
 /// assert!(hash_set.insert(RefCmp(b)));
 /// ```
-pub struct RefCmp<T: Same>(pub T);
+#[repr(transparent)]
+pub struct RefCmp<T: Same + ?Sized>(pub T);
 
-impl<T: Same> Eq for RefCmp<T> {}
-impl<T: Same> PartialEq for RefCmp<T> {
+impl<T: Same + ?Sized> RefCmp<T> {
+    pub fn from_ref(inner: &T) -> &Self {
+        // this is safe thanks to #[repr(transparent)]
+        unsafe { &*(inner as *const _ as *const Self) }
+    }
+}
+
+impl<T: Same + ?Sized> Eq for RefCmp<T> {}
+impl<T: Same + ?Sized> PartialEq for RefCmp<T> {
     fn eq(&self, other: &Self) -> bool {
         self.0.same(&other.0)
     }
 }
 
-impl<T: Same + RefHash> Hash for RefCmp<T> {
+impl<T: Same + RefHash + ?Sized> Hash for RefCmp<T> {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         self.0.ref_hash(hasher);
     }
 }
 
-impl<T: Same> core::ops::Deref for RefCmp<T> {
+impl<T: Same + ?Sized> core::ops::Deref for RefCmp<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -150,13 +195,13 @@ impl<T: Same> core::ops::Deref for RefCmp<T> {
     }
 }
 
-impl<U, T: Same + AsRef<U>> AsRef<U> for RefCmp<T> {
+impl<U, T: Same + AsRef<U> + ?Sized> AsRef<U> for RefCmp<T> {
     fn as_ref(&self) -> &U {
         self.0.as_ref()
     }
 }
 
-impl<T: Same> core::borrow::Borrow<T> for RefCmp<T> {
+impl<T: Same + ?Sized> core::borrow::Borrow<T> for RefCmp<T> {
     fn borrow(&self) -> &T {
         &self.0
     }
@@ -164,8 +209,8 @@ impl<T: Same> core::borrow::Borrow<T> for RefCmp<T> {
 
 #[cfg(test)]
 mod tests {
-    use ::Same;
-    use ::RefCmp;
+    use RefCmp;
+    use Same;
 
     #[test]
     fn refs() {
@@ -183,6 +228,24 @@ mod tests {
         assert!(hash_set.insert(RefCmp(a_ref)));
         assert!(!hash_set.insert(RefCmp(a_ref_again)));
         assert!(hash_set.insert(RefCmp(b_ref)));
+    }
+
+    #[test]
+    fn boxes() {
+        let a = ::std::boxed::Box::new(42);
+        let b = ::std::boxed::Box::new(42);
+
+        let a_box = &a;
+        let a_box_again = &a;
+        let b_box = &b;
+
+        assert!(a_box.same(&a_box_again));
+        assert!(!a_box.same(&b_box));
+
+        let mut hash_set = ::std::collections::HashSet::new();
+        assert!(hash_set.insert(RefCmp(a_box)));
+        assert!(!hash_set.insert(RefCmp(a_box_again)));
+        assert!(hash_set.insert(RefCmp(b_box)));
     }
 
     #[test]


### PR DESCRIPTION
Also, I think it'd be nice to make Same have a generic parameter just as `PartialEq<T = Self>` and `PartialOrd<T = Self>`, but I did not change that because I think it needs discussion.